### PR TITLE
Fix build for original sputnikdao contract

### DIFF
--- a/sputnikdao/src/lib.rs
+++ b/sputnikdao/src/lib.rs
@@ -63,8 +63,8 @@ fn vote_requirement(policy: &[PolicyItem], num_council: u64, amount: Option<Bala
     policy[policy.len() - 1].num_votes(num_council)
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
-#[cfg_attr(not(target_arch = "wasm32"), derive(Clone, Debug, Eq, PartialEq))]
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Eq))]
 #[serde(crate = "near_sdk::serde")]
 pub enum ProposalStatus {
     /// Proposal is in active voting stage.


### PR DESCRIPTION
Fixes #22 

Seems that there were some issues with the way derives were used here.

Problem: could not run `./build.sh` in the directory `sputnikdao`.

Results: building and running tests in this directory does not fail.