### PR TITLE
Upon successful BountyDone proposal, ensure proper claim is removed

### DIFF
--- a/sputnikdao2/src/bounties.rs
+++ b/sputnikdao2/src/bounties.rs
@@ -124,6 +124,8 @@ impl Contract {
             deadline.0 <= bounty.max_deadline.0,
             "ERR_BOUNTY_WRONG_DEADLINE"
         );
+        // Check that account hasn't already claimed this bounty
+        assert!(!self.bounty_claimers.contains_key(&env::predecessor_account_id()), "ERR_ALREADY_CLAIMED");
         self.bounty_claims_count.insert(&id, &(claims_count + 1));
         let mut claims = self
             .bounty_claimers

--- a/sputnikdao2/src/lib.rs
+++ b/sputnikdao2/src/lib.rs
@@ -8,7 +8,7 @@ use near_sdk::{
     env, near_bindgen, AccountId, Balance, BorshStorageKey, CryptoHash, PanicOnDefault, Promise,
 };
 
-use crate::bounties::{Bounty, BountyClaim, VersionedBounty};
+pub use crate::bounties::{Bounty, BountyClaim, VersionedBounty};
 pub use crate::policy::{Policy, RoleKind, RolePermission, VersionedPolicy, VotePolicy};
 use crate::proposals::VersionedProposal;
 pub use crate::proposals::{Proposal, ProposalInput, ProposalKind, ProposalStatus};

--- a/sputnikdao2/src/proposals.rs
+++ b/sputnikdao2/src/proposals.rs
@@ -416,6 +416,11 @@ impl Contract {
                 self.staking_id.is_none(),
                 "ERR_STAKING_CONTRACT_CANT_CHANGE"
             ),
+            ProposalKind::AddBounty { bounty } => assert_ne!(
+                bounty.times,
+                0,
+                "ERR_BOUNTY_TIMES_ZERO"
+            ),
             // TODO: add more verifications.
             _ => {}
         };

--- a/sputnikdao2/tests/test_bounties.rs
+++ b/sputnikdao2/tests/test_bounties.rs
@@ -1,0 +1,87 @@
+use sputnikdao2::{ProposalInput, ProposalKind, Bounty, BountyClaim};
+
+use crate::utils::*;
+use near_sdk_sim::{call, to_yocto, UserAccount, view};
+use near_sdk::json_types::U128;
+use near_sdk_sim::transaction::ExecutionStatus;
+use near_sdk::serde::export::TryFrom;
+
+mod utils;
+
+// Helper functions
+
+fn setup_addbounty_proposal() -> (UserAccount, Contract, UserAccount) {
+    let (root, dao) = setup_dao();
+    let bounty_hunter = root.create_user(user(1), to_yocto("1000"));
+    add_proposal(
+        &root,
+        &dao,
+        ProposalInput {
+            description: "add bounty".to_string(),
+            kind: ProposalKind::AddBounty {
+                bounty: Bounty {
+                    description: "".to_string(),
+                    token: "".to_string(),
+                    amount: U128(to_yocto("5")),
+                    times: 1,
+                    max_deadline: U64(1925376849430593581)
+                }
+            },
+        },
+    )
+    .assert_success();
+
+    // Vote the AddBounty proposal in
+    vote(vec![&root], &dao, 0);
+
+    // Bounty hunter claims bounty
+    call!(
+        bounty_hunter,
+        dao.bounty_claim(0, U64::from(1725376849430593581)),
+        deposit = to_yocto("1")
+    )
+    .assert_success();
+
+    (root, dao, bounty_hunter)
+}
+
+// Tests
+
+#[test]
+fn test_bounty_claim_multiple() {
+    let (_, dao, bounty_hunter) = setup_addbounty_proposal();
+
+    // Tries to claim again and should get an error
+    let double_claim_status = call!(
+        bounty_hunter,
+        dao.bounty_claim(0, U64::from(1725376849430593581)),
+        deposit = to_yocto("1")
+    ).status();
+    match double_claim_status {
+        ExecutionStatus::Failure(f) => {
+            assert!(f.to_string().contains("ERR_BOUNTY_ALL_CLAIMED"), "Didn't receive expected failure message.");
+        }
+        _ => panic!("Expected failure when account tries to claim same bounty twice.")
+    }
+}
+
+#[test]
+fn test_bounty_withdraw_claim() {
+    let (_, dao, bounty_hunter) = setup_addbounty_proposal();
+    let mut bounty_num_claims = view!(dao.get_bounty_number_of_claims(0)).unwrap_json::<u32>();
+    assert_eq!(bounty_num_claims, 1, "Bounty should have only one bounty claimed.");
+    let mut bounty_hunter_claims = view!(dao.get_bounty_claims(ValidAccountId::try_from(user(1)).unwrap())).unwrap_json::<Vec<BountyClaim>>();
+    assert_eq!(bounty_hunter_claims.len(), 1, "Claimant should only have one bounty claimed.");
+
+    // User withdraws claim
+    call!(
+        bounty_hunter,
+        dao.bounty_giveup(0)
+    ).assert_success();
+
+    // Both bounty and user should now have 0 claims
+    bounty_num_claims = view!(dao.get_bounty_number_of_claims(0)).unwrap_json();
+    assert_eq!(bounty_num_claims, 0, "Bounty should have zero claims.");
+    bounty_hunter_claims = view!(dao.get_bounty_claims(ValidAccountId::try_from(user(1)).unwrap())).unwrap_json();
+    assert_eq!(bounty_hunter_claims.len(), 0, "Claimant should now have zero claims.");
+}

--- a/sputnikdao2/tests/test_general.rs
+++ b/sputnikdao2/tests/test_general.rs
@@ -14,10 +14,6 @@ use crate::utils::*;
 
 mod utils;
 
-fn user(id: u32) -> String {
-    format!("user{}", id)
-}
-
 #[test]
 fn test_multi_council() {
     let (root, dao) = setup_dao();

--- a/sputnikdao2/tests/utils/mod.rs
+++ b/sputnikdao2/tests/utils/mod.rs
@@ -21,7 +21,7 @@ near_sdk_sim::lazy_static_include::lazy_static_include_bytes! {
     STAKING_WASM_BYTES => "../sputnik-staking/res/sputnik_staking.wasm",
 }
 
-type Contract = ContractAccount<DAOContract>;
+pub type Contract = ContractAccount<DAOContract>;
 
 pub fn base_token() -> String {
     "".to_string()
@@ -135,4 +135,8 @@ pub fn vote(users: Vec<&UserAccount>, dao: &Contract, proposal_id: u64) {
 
 pub fn to_va(a: AccountId) -> ValidAccountId {
     ValidAccountId::try_from(a).unwrap()
+}
+
+pub fn user(id: u32) -> String {
+    format!("user{}", id)
 }


### PR DESCRIPTION
Fixes #27 #29 

It looks like there was an assumption that we could use the `env::predecessor_account_id` somewhere that didn't turn out true in all cases. Specifically, the case laid out in the issue linked above. When a council members is the final vote to approve a `BountyDone` proposal, we don't want to use that person as the key, which is fixed by this PR.

Added 2 simulation tests for bounties, making sure:
- an account can only claim the same bounty once.
- withdrawing (currently called "give up") works properly

Also, as a flyby, added small validation that a proposal of kind `AddBounty` cannot say, "this can be claimed 0 times"