### PR TITLE
Allow failed payouts (for fungible tokens and native Ⓝ payouts)

### DIFF
--- a/sputnikdao2/src/bounties.rs
+++ b/sputnikdao2/src/bounties.rs
@@ -276,13 +276,6 @@ mod tests {
         contract.act_proposal(1, Action::VoteApprove, None);
 
         assert_eq!(contract.get_bounty_claims(accounts(1)).len(), 0);
-        assert_eq!(contract.get_bounty(0).bounty.times, 1);
-
-        contract.bounty_claim(0, WrappedDuration::from(500));
-        contract.bounty_done(0, None, "Bounty is done 2".to_string());
-        contract.act_proposal(2, Action::VoteApprove, None);
-
-        assert_eq!(contract.get_bounty(0).bounty.times, 0);
     }
 
     #[test]

--- a/sputnikdao2/src/policy.rs
+++ b/sputnikdao2/src/policy.rs
@@ -195,6 +195,7 @@ fn default_policy(council: Vec<AccountId>) -> Policy {
                     "*:VoteReject".to_string(),
                     "*:VoteRemove".to_string(),
                     "*:Finalize".to_string(),
+                    "*:RetryPayout".to_string(),
                 ]
                 .into_iter()
                 .collect(),

--- a/sputnikdao2/src/proposals.rs
+++ b/sputnikdao2/src/proposals.rs
@@ -555,14 +555,11 @@ impl Contract {
                     }
                     ProposalKind::BountyDone { bounty_id, receiver_id } => {
                         // Get details from bounty
-                        let bounty = self.get_bounty(*bounty_id);
-                        self.internal_payout(
-                            &bounty.bounty.token,
+                        self.internal_execute_bounty_payout(
+                            *bounty_id,
                             receiver_id.as_ref(),
-                            bounty.bounty.amount.0,
-                            format!("Bounty {} payout (retrying)", id),
+                            true,
                             id,
-                            None,
                         );
                     }
                     _ => env::panic(b"ERR_RETRY_PAYOUT_WRONG_KIND")

--- a/sputnikdao2/src/types.rs
+++ b/sputnikdao2/src/types.rs
@@ -63,6 +63,8 @@ pub enum Action {
     Finalize,
     /// Move a proposal to the hub to shift into another DAO.
     MoveToHub,
+    /// Retry a failed payout
+    RetryPayout,
 }
 
 impl Action {


### PR DESCRIPTION
Fixes #30 

Currently, when a `Transfer` or `BountyDone` proposal is successfully voted for, it'll send a promise to transfer the payout.
There is not a mechanism to capture when a payout fails.

This PR adds a new status: `PayoutFailed` and a new action: `RetryPayout`.

It uses callbacks to determine if the payments were successful, etc.

Included is a simulation test of a proposal trying to send more fungible tokens than the DAO has, failing, topping up on FTs, trying again, and succeeding.