### PR TITLE
Make bounty_done payable

### DIFF
--- a/sputnikdao2/src/bounties.rs
+++ b/sputnikdao2/src/bounties.rs
@@ -166,6 +166,7 @@ impl Contract {
     /// Report that bounty is done. Creates a proposal to vote for paying out the bounty.
     /// Only creator of the claim can call `done` on bounty that is still in progress.
     /// On expired, anyone can call it to free up the claim slot.
+    #[payable]
     pub fn bounty_done(&mut self, id: u64, account_id: Option<AccountId>, description: String) {
         let sender_id = account_id.unwrap_or_else(|| env::predecessor_account_id());
         let (mut claims, claim_idx) = self.internal_get_claims(id, &sender_id);


### PR DESCRIPTION
Fixes #36 and thanks Moses for finding this out the hard way.

The function `bounty_done` explains its purpose in the comments above it, but will essentially create a proposal. Proposals (most if not all) need a bond payment in native NEAR. This needs to be payable. This is just a small oversight but hinders the progress and makes this function useless until we add this.

To demonstrate this problem, you can set up a bash script like the following, replacing the environment variables with the ones you have. I have placed a similar bash script in the `sputnikdao2` directory:

```sh
#!/bin/sh

# Change these to your account ids
./build.sh
export CONTRACT_ID=sputnikdao2.mike.testnet
export CONTRACT_PARENT=mike.testnet

# Redo account (if contract already exists)
near delete $CONTRACT_ID $CONTRACT_PARENT
near create-account $CONTRACT_ID --masterAccount $CONTRACT_PARENT

# Set up
near deploy $CONTRACT_ID --wasmFile ~/near/sputnik-dao-contract/sputnikdao2/res/sputnikdao2.wasm
export COUNCIL='["'$CONTRACT_ID'"]'
near call $CONTRACT_ID new '{"config": {"name": "genesis2", "purpose": "test", "metadata": ""}, "policy": '$COUNCIL'}' --accountId $CONTRACT_ID

# Add proposal for a Transfer kind that pays out 19 NEAR
near call $CONTRACT_ID add_proposal '{"proposal": {"description": "test bounty", "kind": {"AddBounty": {"bounty": {"description": "do the thing", "token": "", "amount": "19000000000000000000000000", "times": 3, "max_deadline": "1925376849430593581"}}}}}' --accountId $CONTRACT_PARENT --amount 1

# Show error when a user tries to vote along with log
near call $CONTRACT_ID act_proposal '{"id": 0, "action": "VoteApprove"}' --accountId $CONTRACT_ID

# Someone claims bounty
near call $CONTRACT_ID bounty_claim '{"id": 0, "deadline": "1925376849430593581"}' --accountId $CONTRACT_PARENT --amount 1

# Show bounty claims
near view $CONTRACT_ID get_bounty_claims '{"account_id": "'$CONTRACT_PARENT'"}'

# Call bounty_done
near call $CONTRACT_ID bounty_done '{"id": 0, "description": "was not even hard. ez"}'  --accountId $CONTRACT_PARENT --amount 1
```

If you run the above code without this PR's 1-line change, it will fail. With it, it succeeds, pretty simple.