### PR TITLE
Fix compilation error that occurs with the latest version of near-sdk

### DIFF
--- a/sputnikdao-factory2/src/lib.rs
+++ b/sputnikdao-factory2/src/lib.rs
@@ -148,7 +148,7 @@ mod tests {
         );
         assert_eq!(
             factory.get_daos(0, 100),
-            vec![format!("test.{}", accounts(0))]
+            vec![format!("test.{}", accounts(0)).parse().unwrap()]
         );
     }
 }


### PR DESCRIPTION
This error occurs when running `cargo test` with the `master` branch from [near-sdk](https://github.com/near/near-sdk-rs).

Error displayed is:
```
error[E0277]: can't compare `AccountId` with `std::string::String`
   --> sputnikdao-factory2/src/lib.rs:149:9
    |
149 | /         assert_eq!(
150 | |             factory.get_daos(0, 100),
151 | |             vec![format!("test.{}", accounts(0))]
152 | |         );
    | |__________^ no implementation for `AccountId == std::string::String`
```