### PR TITLE
add pull_request to GitHub workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,9 @@
 name: Tests
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
   tests:
     strategy:


### PR DESCRIPTION
Looks like the CI hasn't been running for pull requests. This is my fault I believe, as I made the initial GitHub workflows. Let's fix that so we don't accidentally merge PRs that don't pass tests.