### PR TITLE
Updating policy partially via JSON paths

### DIFF
--- a/sputnikdao2/src/policy.rs
+++ b/sputnikdao2/src/policy.rs
@@ -355,7 +355,6 @@ impl Policy {
         roles: Vec<String>,
         total_supply: Balance,
     ) -> ProposalStatus {
-        env::log_str(&format!("{:?}", roles));
         assert!(
             matches!(
                 proposal.status,


### PR DESCRIPTION
Example to just rename 0th role to `test`: `update_policy '{"updates": [{"path": "roles/0/name", "new_value": "\"test\"\"}]}'`