### PR TITLE
Fix bug where locked_amount and get_available_amount() show incorrect results

### DIFF
--- a/sputnikdao2/src/bounties.rs
+++ b/sputnikdao2/src/bounties.rs
@@ -128,6 +128,7 @@ impl Contract {
         });
         self.bounty_claimers
             .insert(&env::predecessor_account_id(), &claims);
+        self.locked_amount += env::attached_deposit();
     }
 
     /// Removes given claims from this bounty and user's claims.
@@ -195,6 +196,7 @@ impl Contract {
             PromiseOrValue::Value(())
         } else {
             // Within forgiveness period. Return bond.
+            self.locked_amount -= policy.bounty_bond.0;
             Promise::new(env::predecessor_account_id())
                 .transfer(policy.bounty_bond.0)
                 .into()

--- a/sputnikdao2/src/lib.rs
+++ b/sputnikdao2/src/lib.rs
@@ -47,9 +47,6 @@ pub struct Contract {
     /// Voting and permissions policy.
     pub policy: LazyOption<VersionedPolicy>,
 
-    /// Amount of $NEAR locked for storage / bonds.
-    pub locked_amount: Balance,
-
     /// Vote staking contract id. That contract must have this account as owner.
     pub staking_id: Option<AccountId>,
     /// Delegated  token total amount.
@@ -92,8 +89,6 @@ impl Contract {
             bounty_claimers: LookupMap::new(StorageKeys::BountyClaimers),
             bounty_claims_count: LookupMap::new(StorageKeys::BountyClaimCounts),
             blobs: LookupMap::new(StorageKeys::Blobs),
-            // TODO: only accounts for contract but not for this state object. Can just add fixed size of it.
-            locked_amount: env::storage_byte_cost() * (env::storage_usage() as u128),
         }
     }
 
@@ -125,7 +120,6 @@ impl Contract {
         env::storage_remove(&hash);
         let blob_len = env::register_len(u64::MAX - 1).unwrap();
         let storage_cost = ((blob_len + 32) as u128) * env::storage_byte_cost();
-        self.locked_amount -= storage_cost;
         Promise::new(account_id).transfer(storage_cost)
     }
 }
@@ -190,7 +184,6 @@ pub extern "C" fn store_blob() {
             "ERR_NOT_ENOUGH_DEPOSIT:{}",
             storage_cost
         );
-        contract.locked_amount += storage_cost;
         // Store value of register 0 into key = register 1.
         sys::storage_write(u64::MAX as _, 1 as _, u64::MAX as _, 0 as _, 2);
         // Load register 1 into blob_hash and save into LookupMap.

--- a/sputnikdao2/src/lib.rs
+++ b/sputnikdao2/src/lib.rs
@@ -47,6 +47,9 @@ pub struct Contract {
     /// Voting and permissions policy.
     pub policy: LazyOption<VersionedPolicy>,
 
+    /// Amount of $NEAR locked for bonds.
+    pub locked_amount: Balance,
+
     /// Vote staking contract id. That contract must have this account as owner.
     pub staking_id: Option<AccountId>,
     /// Delegated  token total amount.
@@ -89,6 +92,7 @@ impl Contract {
             bounty_claimers: LookupMap::new(StorageKeys::BountyClaimers),
             bounty_claims_count: LookupMap::new(StorageKeys::BountyClaimCounts),
             blobs: LookupMap::new(StorageKeys::Blobs),
+            locked_amount: 0,
         }
     }
 

--- a/sputnikdao2/src/proposals.rs
+++ b/sputnikdao2/src/proposals.rs
@@ -256,7 +256,8 @@ impl Contract {
         }
     }
 
-    fn internal_return_bond(&self, policy: &Policy, proposal: &Proposal) -> Promise {
+    fn internal_return_bond(&mut self, policy: &Policy, proposal: &Proposal) -> Promise {
+        self.locked_amount -= policy.proposal_bond.0;
         Promise::new(proposal.proposer.clone()).transfer(policy.proposal_bond.0)
     }
 
@@ -391,7 +392,7 @@ impl Contract {
     ) -> PromiseOrValue<()> {
         if return_bond {
             // Return bond to the proposer.
-            Promise::new(proposal.proposer.clone()).transfer(policy.proposal_bond.0);
+            self.internal_return_bond(policy, proposal);
         }
         match &proposal.kind {
             ProposalKind::BountyDone {
@@ -463,6 +464,7 @@ impl Contract {
         self.proposals
             .insert(&id, &VersionedProposal::Default(proposal.into()));
         self.last_proposal_id += 1;
+        self.locked_amount += env::attached_deposit();
         id
     }
 

--- a/sputnikdao2/src/views.rs
+++ b/sputnikdao2/src/views.rs
@@ -49,9 +49,15 @@ impl Contract {
         env::storage_has_key(&CryptoHash::from(hash))
     }
 
-    /// Returns available amount of NEAR that can be spent (outside of amount for storage and bonds).
+    /// Returns locked amount of NEAR that is used for storage.
+    pub fn get_locked_amount(&self) -> U128 {
+        let locked_amount = env::storage_byte_cost() * (env::storage_usage() as u128);
+        U128(locked_amount)
+    }
+
+    /// Returns available amount of NEAR that can be spent (outside of amount for storage).
     pub fn get_available_amount(&self) -> U128 {
-        U128(env::account_balance() - self.locked_amount)
+        U128(env::account_balance() - self.get_locked_amount().0)
     }
 
     /// Returns total delegated stake.

--- a/sputnikdao2/src/views.rs
+++ b/sputnikdao2/src/views.rs
@@ -50,14 +50,14 @@ impl Contract {
     }
 
     /// Returns locked amount of NEAR that is used for storage.
-    pub fn get_locked_amount(&self) -> U128 {
-        let locked_amount = env::storage_byte_cost() * (env::storage_usage() as u128);
-        U128(locked_amount)
+    pub fn get_locked_storage_amount(&self) -> U128 {
+        let locked_storage_amount = env::storage_byte_cost() * (env::storage_usage() as u128);
+        U128(locked_storage_amount)
     }
 
-    /// Returns available amount of NEAR that can be spent (outside of amount for storage).
+    /// Returns available amount of NEAR that can be spent (outside of amount for storage and bonds).
     pub fn get_available_amount(&self) -> U128 {
-        U128(env::account_balance() - self.get_locked_amount().0)
+        U128(env::account_balance() - self.get_locked_storage_amount().0 - self.locked_amount)
     }
 
     /// Returns total delegated stake.


### PR DESCRIPTION
I've experienced this issue while working on a different PR.

`locked_amount` does not display the correct result. The amount of near locked for storage is higher than what `locked_amount` displays. Because of this, `self.get_available_amount()` which is using `locked_amount` also does not display the correct result.

If you try to call this from the contract:
`Promise::new(account_id).transfer(self.get_available_amount().0)` it will fail and it will tell you that if you transfer that amount the contract will not have the necessary NEAR to cover the storage costs.