### PR TITLE
Remove duplicated validation on staking id

### DIFF
--- a/sputnikdao2/src/proposals.rs
+++ b/sputnikdao2/src/proposals.rs
@@ -329,8 +329,7 @@ impl Contract {
                 msg.clone(),
             ),
             ProposalKind::SetStakingContract { staking_id } => {
-                assert!(self.staking_id.is_none(), "ERR_INVALID_STAKING_CHANGE");
-                self.staking_id = Some(staking_id.clone().into());
+                self.staking_id = Some(staking_id.clone());
                 PromiseOrValue::Value(())
             }
             ProposalKind::AddBounty { bounty } => {


### PR DESCRIPTION
Remove unnecessary overhead. The validation already happens here: https://github.com/near-daos/sputnik-dao-contract/blob/main/sputnikdao2/src/proposals.rs#L442-L445