### PR TITLE
Proposal Deadline introduced

### DIFF
--- a/sputnikdao2/src/policy.rs
+++ b/sputnikdao2/src/policy.rs
@@ -6,7 +6,10 @@ use near_sdk::json_types::{U128, U64};
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::{env, AccountId, Balance};
 
-use crate::proposals::{is_deadline_passed, get_biggest_votes_status, PolicyParameters, Proposal, ProposalKind, ProposalStatus, Vote};
+use crate::proposals::{
+    get_biggest_votes_status, is_deadline_passed, PolicyParameters, Proposal, ProposalKind,
+    ProposalStatus, Vote,
+};
 use crate::types::Action;
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone)]
@@ -423,15 +426,14 @@ impl Policy {
             // Check if there is anything voted above the threshold specified by policy for given role.
             let vote_counts = proposal.vote_counts.get(&role).unwrap_or(&[0u128; 3]);
 
-            let threshold = if !is_deadline_passed {
-                std::cmp::max(
-                    vote_policy.quorum.0,
-                    vote_policy.threshold.to_weight(total_weight),
-                )
-            }
-            else {
+            if is_deadline_passed {
                 return get_biggest_votes_status(&vote_counts);
-            };
+            }
+
+            let threshold = std::cmp::max(
+                vote_policy.quorum.0,
+                vote_policy.threshold.to_weight(total_weight),
+            );
 
             if vote_counts[Vote::Approve as usize] >= threshold {
                 return ProposalStatus::Approved;

--- a/sputnikdao2/tests/test_general.rs
+++ b/sputnikdao2/tests/test_general.rs
@@ -58,6 +58,7 @@ fn test_multi_council() {
             kind: ProposalKind::ChangePolicy {
                 policy: VersionedPolicy::Current(new_policy.clone()),
             },
+            deadline: None
         },
     )
     .assert_success();
@@ -152,7 +153,7 @@ fn test_bounty_workflow() {
 
     call!(
         user2,
-        dao.bounty_done(bounty_id, None, "Bounty is done".to_string()),
+        dao.bounty_done(bounty_id, None, "Bounty is done".to_string(), None),
         deposit = to_yocto("1")
     )
     .assert_success();
@@ -236,6 +237,7 @@ fn test_create_dao_and_use_token() {
             kind: ProposalKind::SetStakingContract {
                 staking_id: "staking".parse().unwrap(),
             },
+            deadline: None,
         },
     )
     .assert_success();

--- a/sputnikdao2/tests/test_general.rs
+++ b/sputnikdao2/tests/test_general.rs
@@ -49,6 +49,7 @@ fn test_multi_council() {
         proposal_period: U64::from(1_000_000_000 * 60 * 60 * 24 * 7),
         bounty_bond: U128(10u128.pow(24)),
         bounty_forgiveness_period: U64::from(1_000_000_000 * 60 * 60 * 24),
+        min_voting_time: None,
     };
     add_proposal(
         &root,
@@ -58,7 +59,7 @@ fn test_multi_council() {
             kind: ProposalKind::ChangePolicy {
                 policy: VersionedPolicy::Current(new_policy.clone()),
             },
-            deadline: None
+            deadline: None,
         },
     )
     .assert_success();

--- a/sputnikdao2/tests/test_upgrade.rs
+++ b/sputnikdao2/tests/test_upgrade.rs
@@ -30,7 +30,8 @@ fn test_upgrade() {
         root,
         dao.add_proposal(ProposalInput {
             description: "test".to_string(),
-            kind: ProposalKind::UpgradeSelf { hash }
+            kind: ProposalKind::UpgradeSelf { hash },
+            deadline: None
         }),
         deposit = to_yocto("1")
     )
@@ -87,6 +88,7 @@ fn test_upgrade_other() {
                 method_name: "upgrade".to_string(),
                 hash,
             },
+            deadline: None
         },
     )
     .assert_success();

--- a/sputnikdao2/tests/utils/mod.rs
+++ b/sputnikdao2/tests/utils/mod.rs
@@ -92,9 +92,10 @@ pub fn add_member_proposal(
         ProposalInput {
             description: "test".to_string(),
             kind: ProposalKind::AddMemberToRole {
-                member_id: member_id,
+                member_id,
                 role: "council".to_string(),
             },
+            deadline: None
         },
     )
 }
@@ -118,6 +119,7 @@ pub fn add_transfer_proposal(
                 amount: U128(amount),
                 msg,
             },
+            deadline: None
         },
     )
 }
@@ -137,6 +139,7 @@ pub fn add_bounty_proposal(root: &UserAccount, dao: &Contract) -> ExecutionResul
                     max_deadline: U64(env::block_timestamp() + 10_000_000_000),
                 },
             },
+            deadline: None
         },
     )
 }


### PR DESCRIPTION
Please review how we can introduce time-based voting by setting `deadline` parameter for proposals. 
It means that proposal will be finalised after the deadline even without a majority vote. It may me useful for a really large DAOs. 
I don't know Sputnik DAO structure in details so may be my implementation is naive.