### PR TITLE
Do not allow users to self delegate tokens inside the staking contract

### DIFF
--- a/sputnik-staking/src/user.rs
+++ b/sputnik-staking/src/user.rs
@@ -184,6 +184,7 @@ impl Contract {
         delegate_id: AccountId,
         amount: Balance,
     ) {
+        assert!(sender_id != delegate_id, "ERR_SELF_DELEGATE");
         let mut sender = self.internal_get_user(&sender_id);
         sender.delegate(delegate_id.clone(), amount);
         self.save_user(&sender_id, sender);


### PR DESCRIPTION
Issue reported by Halborn during the audit.

Full description:
The delegate() function in sputnik-staking/lib.rs does not check if sender_id == account_id; as a result, the function caller can delegate votes to itself.