### PR TITLE
Fix setting ARGS in the factory README

### DIFF
--- a/sputnikdao-factory2/README.md
+++ b/sputnikdao-factory2/README.md
@@ -16,9 +16,9 @@ set CONTRACT_ID "dev-1608694678554-8567049"
 near call $CONTRACT_ID new '{}' --accountId $CONTRACT_ID 
 
 # bash
-ARGS=`echo '{"purpose": "test", "council": ["testmewell.testnet", "illia"], "bond": "1000000000000000000000000", "vote_period": "1800000000000", "grace_period": "1800000000000"}' | base64`
+ARGS=`echo '{"config": {"name": "test", "purpose": "test", "metadata": ""}, "policy": ["'$CONTRACT_ID'"]}' | base64`
 # fish
-set ARGS (echo '{"purpose": "test", "council": ["testmewell.testnet", "illia"], "bond": "1000000000000000000000000", "vote_period": "1800000000000", "grace_period": "1800000000000"}' | base64)
+set ARGS (echo '{"config": {"name": "test", "purpose": "test", "metadata": ""}, "policy": ["'$CONTRACT_ID'"]}' | base64)
 
 # Create a new DAO with the given parameters.
 near call $CONTRACT_ID create "{\"name\": \"test\", \"public_key\": null, \"args\": \"$ARGS\"}"  --accountId $CONTRACT_ID --amount 30 --gas 100000000000000


### PR DESCRIPTION
In the current version calling `near call $CONTRACT_ID create "{\"name\": \"test\", \"public_key\": null, \"args\": \"$ARGS\"}"` throws

```
Error: {"index":3,"kind":{"ExecutionError":"Smart contract panicked: panicked at 'Failed to deserialize input from JSON.: Error(\"missing field `config`\", line: 1, column: 165)', sputnikdao2/src/lib.rs:83:1"}}
```

The `new` method (sputnikdao) accepts `config`, `policy` args